### PR TITLE
More short URL functionality

### DIFF
--- a/src/qr_code/templates/qrcode_editor.html
+++ b/src/qr_code/templates/qrcode_editor.html
@@ -42,36 +42,46 @@
     </div>
 
     {% if not qrcode %}
-    <!-- Options row: type + format (only in create mode) -->
-    <div class="mb-4 flex flex-col sm:flex-row sm:items-end gap-4">
-      <div>
-        <label class="block mb-1 text-sm font-medium">Type</label>
-        <select id="qr_type" name="qr_type"
-                class="w-40 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary">
-          <option value="text" selected>Text</option>
-          <option value="url">URL</option>
-        </select>
+    <!-- Options row: type + format + track (only in create mode) -->
+    <div class="mb-4 flex flex-col gap-4">
+      <!-- Type and Format dropdowns -->
+      <div class="flex flex-col sm:flex-row sm:items-end gap-4">
+        <div>
+          <label class="block mb-1 text-sm font-medium">Type</label>
+          <select id="qr_type" name="qr_type"
+                  class="w-40 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary">
+            <option value="text" selected>Text</option>
+            <option value="url">URL</option>
+          </select>
+        </div>
+
+        <div>
+          <label class="block mb-1 text-sm font-medium">Format</label>
+          <select name="qr_format"
+                  class="w-40 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary">
+            <option value="png" selected>PNG</option>
+            <option value="svg">SVG</option>
+            <option value="pdf">PDF</option>
+          </select>
+        </div>
+
+        <div class="flex items-end">
+          <label class="inline-flex items-center gap-2 pb-2">
+            <input id="use_url_shortening" type="checkbox" name="use_url_shortening" value="true" class="rounded" disabled>
+            <span class="text-sm">Track QR Code</span>
+            <i class="fas fa-question-circle text-gray-500 dark:text-gray-400 cursor-help" 
+               title="This tracks the QR Code usage and gives you analytical data about its usage."></i>
+          </label>
+        </div>
       </div>
 
-      <div>
-        <label class="block mb-1 text-sm font-medium">Format</label>
-        <select name="qr_format"
-                class="w-40 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary">
-          <option value="png" selected>PNG</option>
-          <option value="svg">SVG</option>
-          <option value="pdf">PDF</option>
-        </select>
+      <!-- Short URL display (only visible when tracking is enabled) -->
+      <div id="short-url-container" class="hidden">
+        <label class="block mb-1 text-sm font-medium">Short URL</label>
+        <input id="short-url-display" type="text" readonly
+               class="w-full rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-300 px-3 py-2 cursor-default"
+               placeholder="Short URL will be generated...">
       </div>
-    </div>
-
-    <!-- Track QR Code checkbox (only in create mode) -->
-    <div class="mb-6">
-      <label class="inline-flex items-center gap-2">
-        <input id="use_url_shortening" type="checkbox" name="use_url_shortening" value="true" class="rounded" disabled>
-        <span class="text-sm">Track QR Code</span>
-        <i class="fas fa-question-circle text-gray-500 dark:text-gray-400 cursor-help" 
-           title="This tracks the QR Code usage and gives you analytical data about its usage."></i>
-      </label>
     </div>
     {% endif %}
 
@@ -122,14 +132,49 @@
     const isEditMode = {{ qrcode|yesno:"true,false" }};
     const qrTypeSelect = document.getElementById('qr_type');
     const urlShorteningCheckbox = document.getElementById('use_url_shortening');
+    const shortUrlContainer = document.getElementById('short-url-container');
+    const shortUrlDisplay = document.getElementById('short-url-display');
+    let generatedShortCode = null;
 
-    // Update checkbox state based on QR type selection
+    // Generate a random short code (8 characters)
+    function generateShortCode() {
+      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+      let code = '';
+      for (let i = 0; i < 8; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      return code;
+    }
+
+    // Update checkbox state and short URL visibility
     function updateCheckboxState() {
       if (qrTypeSelect && urlShorteningCheckbox) {
         const isUrl = qrTypeSelect.value === 'url';
         urlShorteningCheckbox.disabled = !isUrl;
         if (!isUrl) {
           urlShorteningCheckbox.checked = false;
+          if (shortUrlContainer) {
+            shortUrlContainer.classList.add('hidden');
+          }
+        }
+      }
+    }
+
+    // Update short URL display when checkbox changes
+    function updateShortUrlDisplay() {
+      if (urlShorteningCheckbox && shortUrlContainer && shortUrlDisplay) {
+        if (urlShorteningCheckbox.checked) {
+          shortUrlContainer.classList.remove('hidden');
+          // Generate short code if not already generated
+          if (!generatedShortCode) {
+            generatedShortCode = generateShortCode();
+          }
+          // Display the short URL
+          const baseUrl = window.location.origin;
+          shortUrlDisplay.value = `${baseUrl}/go/${generatedShortCode}/`;
+        } else {
+          shortUrlContainer.classList.add('hidden');
+          generatedShortCode = null;
         }
       }
     }
@@ -142,7 +187,20 @@
       if (qrTypeSelect) {
         qrTypeSelect.addEventListener('change', updateCheckboxState);
       }
+
+      // Add event listener for checkbox changes
+      if (urlShorteningCheckbox) {
+        urlShorteningCheckbox.addEventListener('change', updateShortUrlDisplay);
+      }
     }
+
+    // Intercept htmx requests to add short_code if needed
+    document.body.addEventListener('htmx:configRequest', function(e) {
+      if (e.target === previewBtn && generatedShortCode && urlShorteningCheckbox && urlShorteningCheckbox.checked) {
+        // Add short_code to the request parameters
+        e.detail.parameters.short_code = generatedShortCode;
+      }
+    });
 
     form.addEventListener('submit', function(ev){
       if (!form.checkValidity()) {
@@ -167,8 +225,18 @@
           const data = JSON.parse(e.detail.xhr.responseText || '{}');
           if (status >= 200 && status < 300 && data.image_url) {
             previewImg.src = data.image_url;
+            msg.textContent = '';
+            msg.className = 'mb-4 text-sm';
           } else {
-            const userMsg = data.detail || data.message || 'Could not generate preview.';
+            // Handle URL validation errors specifically
+            let userMsg = '';
+            if (data.url && Array.isArray(data.url)) {
+              userMsg = data.url[0];
+            } else if (data.url) {
+              userMsg = data.url;
+            } else {
+              userMsg = data.detail || data.message || 'Could not generate preview.';
+            }
             msg.textContent = userMsg;
             msg.className = 'mb-4 text-sm text-red-600';
             console.error('Preview error (developer details):', data);
@@ -188,7 +256,15 @@
           if (status >= 200 && status < 300) {
             window.location = '/dashboard/';
           } else {
-            const userMsg = data.detail || data.message || (isEditMode ? 'Could not update QR code.' : 'Could not generate QR code.');
+            // Handle URL validation errors specifically
+            let userMsg = '';
+            if (data.url && Array.isArray(data.url)) {
+              userMsg = data.url[0];
+            } else if (data.url) {
+              userMsg = data.url;
+            } else {
+              userMsg = data.detail || data.message || (isEditMode ? 'Could not update QR code.' : 'Could not generate QR code.');
+            }
             msg.textContent = userMsg;
             msg.className = 'mb-4 text-sm text-red-600';
             console.error((isEditMode ? 'Update' : 'Create') + ' QR error (developer details):', data);


### PR DESCRIPTION
* Show short URL when creating the QR code.
* Validate the URL is valid when QR Code is of type URL.

-----
# Problem Statement
The QR Code create and edit pages need to support selecting and displaying the QR code type (URL or Text). Currently, the type is hardcoded as 'text' in the create form, and there's no UI element for selecting it. Additionally, the "Generate short URL" checkbox needs to be renamed to "Track QR Code" and should only be enabled when the type is URL.
# Current State
* `qrcode_editor.html` has a hidden input field that always sets `qr_type="text"` (line 20)
* The "Generate short URL" checkbox is always enabled and has the text "Generate short URL (for valid URLs only)" (lines 51-54)
* The QRCodeType enum is defined in `models/qrcode.py` with URL and TEXT choices (lines 33-37)
* The form uses a Format dropdown with PNG/SVG/PDF options (lines 42-49)
* Edit mode already makes certain fields read-only (like the content field)
# Proposed Changes
## 1. Update qrcode_editor.html
### Add QR Code Type Dropdown (Create Mode)
* Remove the hidden `qr_type` input field (line 20)
* Add a new Type dropdown next to the Format dropdown in the options row (lines 40-49)
* The Type dropdown should include "URL" and "Text" options from QRCodeType enum
* Default selection should be "Text"
* Layout: both dropdowns in the same row, Type on the left, Format on the right
### Update "Generate short URL" Checkbox
* Change checkbox label from "Generate short URL (for valid URLs only)" to "Track QR Code" (line 53)
* Add Font Awesome question mark icon with tooltip next to the label
* Tooltip text: "This tracks the QR Code usage and gives you analytical data about its usage."
* Add JavaScript logic to enable/disable checkbox based on selected QR code type:
    * Enabled when Type = "url"
    * Disabled when Type = "text"
### Display QR Code Type (Edit Mode)
* Add a read-only field showing the qr_type value when editing
* Display it below the Name field or near other read-only information
* Format: "Type: URL" or "Type: Text"
## 2. Update JavaScript in qrcode_editor.html
* Add event listener for the Type dropdown change event
* When Type changes:
    * If "url": enable the "Track QR Code" checkbox
    * If "text": disable and uncheck the "Track QR Code" checkbox
* Initialize the checkbox state on page load based on default Type selection
## 3. Implementation Details
* Use Tailwind CSS classes to match existing styling
* Ensure proper responsive layout (sm: breakpoints for mobile)
* Maintain dark mode compatibility
* Follow existing form structure and patterns
* The Type dropdown should use the same styling as the Format dropdown
